### PR TITLE
Fix documentation inconsistencies (examples violate different rules).

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -5,14 +5,14 @@
 * Use 4-spaces for indentation (because it's easier to be consistent with Python than it is to switch your editor back and forth).
 * Javascript variables names should always be ``lowercase_with_underscores``.
 * Static variables and configuration parameters should be in ``TITLECASE_WITH_UNDERSCORES``.
-* Named functions should look like this ``var camelCase = function() {}``.
+* Named functions should look like this ``var function_name = function() {}``.
 * All global variables should be defined at the top of the file.
 * All variables should be constrained to the current scope with ``var``.
 * Declare only a single variable on one line.
 * End all statements with a semicolon.
 * Use spaces after opening and before closing braces and brackets in array and object definitions, i.e. ``{ foo: [ 1, 2, 3 ] }`` not ``{foo:[1,2,3]}``.
-* Do not use spaces after opening or before closing parentheses, i.e. ``if (foo == true) {`` and not ``if ( foo == true ) {``. 
-* When accessing properties of a data structure (such as one retrieved using ``getJSON``) prefer bracket syntax (``data["property"]``) to attribute syntax (``data.property``).
+* Do not use spaces after opening or before closing parentheses, i.e. ``if (foo === true) {`` and not ``if ( foo === true ) {``. 
+* When accessing properties of a data structure (such as one retrieved using ``getJSON``) prefer bracket syntax (``data['property']``) to attribute syntax (``data.property``).
 * Very frequent property references should be cached, i.e. ``var array_length = array.length;``.
 * Use ``===`` rather than ``==``. ([Why?](http://www.impressivewebs.com/why-use-triple-equals-javascipt/))
 * **Use single-quotes for strings.**
@@ -29,7 +29,7 @@ For consistency, prefer the following libraries to others that perform the same 
 
 ### jQuery-specific
 
-* jQuery references that are used more than once should be cached. Prefix these references with ``$``, i.e. ``var $electris = $("#electris");``.
-* Whenever possible constrain jQuery DOM lookups within the scope of a cached element. For example, ``$electris.find(".candidate")`` is preferable to ``$(".candidate")``.
+* jQuery references that are used more than once should be cached. Prefix these references with ``$``, i.e. ``var $electris = $('#electris');``.
+* Whenever possible constrain jQuery DOM lookups within the scope of a cached element. For example, ``$electris.find('.candidate')`` is preferable to ``$('.candidate')``.
 * Always use [on](http://api.jquery.com/on/), never [bind](http://api.jquery.com/bind/), [delegate](http://api.jquery.com/delegate/) or [live](http://api.jquery.com/live/). ``on`` should also be preferred to "verb events", such as [click](http://api.jquery.com/click/).
 


### PR DESCRIPTION
I noticed that several of the examples contradict rules (double quotes, == instead of ===, a mix of camel case and underscores.) This seemed slightly confusing, so here's a pull request that attempts to address it. Feel free to disregard if a more complete update is underway. Thanks!
